### PR TITLE
feat: setup Google Login for Desktop and Android

### DIFF
--- a/foliary/src/commonMain/kotlin/dev/appoutlet/foliary/feature/signin/SignInScreen.kt
+++ b/foliary/src/commonMain/kotlin/dev/appoutlet/foliary/feature/signin/SignInScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -159,7 +160,10 @@ private fun UnAuthenticatedContent(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        SocialLoginButtons(onEvent = onEvent)
+        SocialLoginButtons(
+            state = state,
+            onEvent = onEvent
+        )
 
         Spacer(modifier = Modifier.height(24.dp))
 
@@ -185,15 +189,28 @@ private fun UnAuthenticatedContent(
 }
 
 @Composable
-private fun SocialLoginButtons(onEvent: (SignInEvent) -> Unit) {
+private fun SocialLoginButtons(
+    state: SignInViewData.NotAuthenticated,
+    onEvent: (SignInEvent) -> Unit
+) {
     FoliaryOutlinedButton(
         onClick = { onEvent(SignInEvent.OnGoogleSignInClick) },
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
+        enabled = state.requestingGoogleAuthentication.not() && state.requestingMagicLink.not()
     ) {
-        Image(
-            painter = painterResource(Res.drawable.ic_google),
-            contentDescription = null,
-        )
+        AnimatedContent(state.requestingGoogleAuthentication) { requestingGoogleAuthentication ->
+            if (requestingGoogleAuthentication) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
+            } else {
+                Image(
+                    painter = painterResource(Res.drawable.ic_google),
+                    contentDescription = null,
+                )
+            }
+        }
         Spacer(modifier = Modifier.width(16.dp))
         Text(
             text = stringResource(Res.string.sign_in_continue_with_google),

--- a/foliary/src/commonMain/kotlin/dev/appoutlet/foliary/feature/signin/SignInViewModel.kt
+++ b/foliary/src/commonMain/kotlin/dev/appoutlet/foliary/feature/signin/SignInViewModel.kt
@@ -68,6 +68,15 @@ class SignInViewModel(
     fun onTryAgain() = intent { reduce { SignInViewData.NotAuthenticated() } }
 
     private fun processDeeplink(deepLink: Deeplink) = intent {
+        val error = deepLink.queryParameters["error"]
+        val errorDescription = deepLink.queryParameters["error_description"]
+
+        if (error != null) {
+            reduce { SignInViewData.NotAuthenticated() }
+            onError(ErrorState(error = Throwable(error), message = errorDescription))
+            return@intent
+        }
+
         val accessToken = deepLink.queryParameters["access_token"] ?: return@intent
         val refreshToken = deepLink.queryParameters["refresh_token"] ?: return@intent
 
@@ -86,7 +95,13 @@ class SignInViewModel(
     }
 
     private fun handleGoogleSignIn() = intent {
-        TODO("Will be implemented in https://github.com/MessiasLima/Foliary/issues/16")
+        reduce { SignInViewData.NotAuthenticated(requestingGoogleAuthentication = true) }
+        try {
+            authenticationRepository.requestGoogleAuthentication()
+        } catch (throwable: Throwable) {
+            reduce { SignInViewData.NotAuthenticated(requestingGoogleAuthentication = false) }
+            onError(ErrorState(throwable))
+        }
     }
 
     private fun handleAppleSignIn() = intent {
@@ -101,7 +116,10 @@ class SignInViewModel(
 
 sealed interface SignInViewData {
     data object Idle : SignInViewData
-    data class NotAuthenticated(val requestingMagicLink: Boolean = false) : SignInViewData
+    data class NotAuthenticated(
+        val requestingMagicLink: Boolean = false,
+        val requestingGoogleAuthentication: Boolean = false
+    ) : SignInViewData
     data class MagicLinkSent(val email: String) : SignInViewData
     data object Loading : SignInViewData
     data class Authenticated(val userName: String, val newUser: Boolean) : SignInViewData


### PR DESCRIPTION
## Summary
- Implemented Google Sign-In in `SignInViewModel` using the Supabase OAuth provider.
- Added `requestingGoogleAuthentication` loading state to `SignInViewData.NotAuthenticated` to show a progress indicator on the Google button.
- Enhanced `processDeeplink` to handle and display error parameters returned by the Supabase OAuth flow.
- Updated `SignInScreen` UI to show the loading indicator when Google authentication is in progress.